### PR TITLE
Update composer to support guzzlehttp/psr7 > 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-curl": "*",
         "ext-libxml": "*",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
-        "guzzlehttp/psr7": "^1.0",
+        "guzzlehttp/psr7": "^1.0 || ^2.0",
         "guzzlehttp/promises": "^1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "benmorel/ebay-sdk-php",
+    "name": "xtremevision/ebay-sdk-php",
     "description": "An eBay SDK for PHP. Fork of dts/ebay-sdk-php with support for PHP 8.",
     "keywords": ["ebay", "api", "sdk"],
     "type": "library",


### PR DESCRIPTION
Trying to install the sdk in Magento 2.4.6 but I am getting version 0.6.0 which lacks a lot of classes.
When trying to in stall version 19.1.0 I am getting a conflicts with guzzlehttps/psr7:

```
[root@localhost htdocs]# php81 composer.phar require benmorel/ebay-sdk-php:19.1.0
./composer.json has been updated
Running composer update benmorel/ebay-sdk-php
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires benmorel/ebay-sdk-php 19.1.0 -> satisfiable by benmorel/ebay-sdk-php[19.1.0].
    - benmorel/ebay-sdk-php 19.1.0 requires guzzlehttp/psr7 ^1.0 -> found guzzlehttp/psr7[1.0.0, ..., 1.9.1] but the package is fixed to 2.6.1 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```

Please merge the PR so I can try reinstalling.

Thanks