### PR TITLE
fix: remove deprecated param from http_build_query function

### DIFF
--- a/src/OAuth/Services/OAuthService.php
+++ b/src/OAuth/Services/OAuthService.php
@@ -189,7 +189,7 @@ class OAuthService
 
         ];
 
-        return $url.http_build_query($urlParams, null, '&', PHP_QUERY_RFC3986);
+        return $url.http_build_query($urlParams, '', '&', PHP_QUERY_RFC3986);
     }
 
     /**
@@ -360,7 +360,7 @@ class OAuthService
             return $carry;
         }, []);
 
-        return empty($request) ? '' : http_build_query($params, null, '&', PHP_QUERY_RFC3986);
+        return empty($request) ? '' : http_build_query($params, '', '&', PHP_QUERY_RFC3986);
     }
 
     /**


### PR DESCRIPTION
Error: http_build_query(): Passing null to parameter 2 ($numeric_prefix) of type string is deprecated.

https://www.php.net/manual/en/function.http-build-query.php